### PR TITLE
feat: add trending history tracking to repos

### DIFF
--- a/backend/interfaces/database.ts
+++ b/backend/interfaces/database.ts
@@ -17,6 +17,7 @@ export interface IRepo extends Document {
   age: number;
   license: string;
   trendingDate: string;
+  trendingRecord: string[];
 }
 
 export interface IStarHistoryEntry {

--- a/backend/model/Repo.ts
+++ b/backend/model/Repo.ts
@@ -13,6 +13,7 @@ const RepoSchema = new mongoose.Schema({
   lastUpdate: String,
   license: String,
   trendingDate: String,
+  trendingRecord: { type: [String], default: [] },
 });
 
 const StarHistorySchema = new mongoose.Schema({

--- a/backend/scraping/repo-data.ts
+++ b/backend/scraping/repo-data.ts
@@ -121,7 +121,10 @@ export async function saveTrendingData(repos: ProcessedRepo[]): Promise<void> {
   const ops = repos.map((repo) => ({
     updateOne: {
       filter: { owner: repo.owner, name: repo.name },
-      update: { $set: repo },
+      update: { 
+        $set: repo,
+        $addToSet: { trendingRecord: repo.trendingDate }
+      },
       upsert: true,
     },
   }));

--- a/frontend/src/components/repo/repo-card.tsx
+++ b/frontend/src/components/repo/repo-card.tsx
@@ -35,6 +35,7 @@ export function RepoCard({
   url,
   topics,
   language,
+  trendingRecord,
   colorIndex = 0,
 }: RepoProps & { colorIndex?: number }) {
   const repoColor = getColor(colorIndex);
@@ -50,6 +51,7 @@ export function RepoCard({
           </CardTitle>
           <CardDescription>
             <RepoTopics topics={topics}></RepoTopics>
+            <TrendingHistory trendingRecord={trendingRecord} />
           </CardDescription>
         </div>
       </CardHeader>
@@ -123,5 +125,24 @@ export function RepoName({
     <a href={url} rel="noopener noreferrer" target="_blank">
       {owner + "/" + name}
     </a>
+  );
+}
+
+export function TrendingHistory({ trendingRecord }: { trendingRecord: string[] }) {
+  if (!trendingRecord || trendingRecord.length === 0) {
+    return null;
+  }
+
+  const trendingCount = trendingRecord.length;
+  const sortedDates = [...trendingRecord].sort((a, b) => b.localeCompare(a));
+  const displayDates = sortedDates.slice(0, 3);
+  const hasMoreDates = sortedDates.length > 3;
+
+  return (
+    <div className="text-xs text-gray-500 mt-1">
+      Previously trending {trendingCount} time{trendingCount > 1 ? 's' : ''} on{' '}
+      {displayDates.join(', ')}
+      {hasMoreDates && ` and ${sortedDates.length - 3} more dates`}
+    </div>
   );
 }

--- a/frontend/src/hooks/useTrendingRepos.tsx
+++ b/frontend/src/hooks/useTrendingRepos.tsx
@@ -18,6 +18,7 @@ export interface Repo {
   age: number;
   license: string;
   trendingDate: string;
+  trendingRecord: string[];
 }
 
 interface Repos {
@@ -32,6 +33,7 @@ export interface RepoProps {
   url: string;
   language: LanguageMap;
   topics: string[];
+  trendingRecord: string[];
 }
 
 export interface RepoCardProps extends Repo {
@@ -93,6 +95,7 @@ export function processRepos(data: Repos): RepoProps[] {
       url: r.url,
       topics: r.topics,
       language: r.language,
+      trendingRecord: r.trendingRecord || [],
     };
   });
   return processedRepos;


### PR DESCRIPTION
## Summary
- Add trendingRecord field to Repo model and interface as array of YYYY-MM-DD strings  
- Update scraper to track historical trending dates using $addToSet
- Display trending history in repo cards showing previous trending dates
- Maintain backward compatibility with existing trendingDate field